### PR TITLE
feat(LazyInvent): add prop to handle delayed load and include sizes prop into srcset

### DIFF
--- a/src/components/ui-carousel.vue
+++ b/src/components/ui-carousel.vue
@@ -11,6 +11,7 @@
             class="ui-carousel__thumbnails__image"
             :alt="`thumbnails-${item.alt}`"
             :src="item.src"
+            sizes="5.6vw"
             :srcset="item.srcSets"
           ></ui-lazy-invent>
         </a>
@@ -34,6 +35,9 @@
             :alt="item.alt"
             :src="item.src"
             :srcset="item.srcSets"
+            :delayLoad="!isFirstImageLoaded && index !== 0"
+            sizes="(max-width: 768px) 36.2vw, 90vw"
+            @on-image-loaded="onImageLoaded(index)"
             @on-image-error="onImageError(index)"
           ></ui-lazy-invent>
           <div
@@ -70,6 +74,11 @@ interface ImgItem {
 
 export default Vue.extend({
   name: 'UiCarousel',
+  data() {
+    return {
+      isFirstImageLoaded: false
+    }
+  },
   components: {
     UiLazyInvent
   },
@@ -103,6 +112,12 @@ export default Vue.extend({
     handleEyeIcon ($event: Event, imageIndex: number): void {
       $event.preventDefault()
       this.$emit('on-click-eye-icon', imageIndex)
+    },
+
+    onImageLoaded (index: number): void {
+      if( index===0 ) {
+        this.isFirstImageLoaded = true
+      }
     },
 
     onImageError (refIndex: number): void {

--- a/src/components/ui-lazy-invent.vue
+++ b/src/components/ui-lazy-invent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isHidden"
+  <div v-if="isHidden || delayLoad"
        ref="visibilityPlaceholder"
        class="placeholder-image placeholder-image--loading"
        v-observe-visibility="{
@@ -18,6 +18,7 @@
     ref="main"
     :src="src"
     :srcset="srcset"
+    :sizes="sizes"
     :alt="alt"
     :class="[
       'lazy-image',
@@ -61,16 +62,32 @@ export default Vue.extend({
       default: ''
     },
     /**
+     * Usage image size
+     */
+    sizes: {
+      type: String,
+      default: ''
+    },
+    /**
      * Text to use in accesibility mode
      */
     alt: {
       type: String,
       default: ''
+    },
+    /**
+     * Whether the image should still showing a loading state until parent requires it
+     */
+    delayLoad: {
+      type: Boolean,
+      default: false
     }
   },
   methods: {
     onVisibilityChanged(isVisible: boolean): void {
+      console.log('isVisible', isVisible)
       if (isVisible) {
+        console.log('isVisible', isVisible, this.src)
         this.isHidden = false
         this.loadingImage = addSiblingNodeWithLoadingImage(this.$refs.visibilityPlaceholder as HTMLElement)
         this.loadingImage?.classList.add('lazy-image__loading')


### PR DESCRIPTION
[BH-7862](https://nextchance.atlassian.net/browse/BH-7862)

- Load images on product detail after first one is loaded
- Added sizes prop cause browsers are not detecting properly the required image size from thumbnails

![image](https://user-images.githubusercontent.com/15434686/113573344-3eb07580-961a-11eb-92a1-3887f731730f.png)
