### PR TITLE
fix(Mixins): return deleted classes on ellipsis mixin

### DIFF
--- a/src/assets/scss/core/_mixins.scss
+++ b/src/assets/scss/core/_mixins.scss
@@ -163,7 +163,8 @@
 //ellipsis
 @mixin ellipsis($lines) {
   box-orient: vertical;
-  display: flex;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
   -webkit-line-clamp: $lines;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
![00107746005235____2__640x640](https://user-images.githubusercontent.com/15434686/115725195-ebf8ec80-a381-11eb-87b6-b698b8812ce0.jpg)
Cable recovery