### PR TITLE
Bugfix/bh 11018 profile header link removable

### DIFF
--- a/src/components/ui-influencer-card.vue
+++ b/src/components/ui-influencer-card.vue
@@ -18,6 +18,7 @@
       :user-name="profile.instagram_handler"
       :secondary-info="date"
       :profile-route="profileRoute"
+      has-profile-link
       @on-more-options-clicked="onMoreOptionsClicked"
       @on-profile-clicked="onProfileClicked"
     />

--- a/src/components/ui-profile-header.vue
+++ b/src/components/ui-profile-header.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="ui-profile-header">
-    <a
+    <component
+      :is="hasProfileLink ? 'a' : 'span'"
+      :href="profileRoute"
       class="ui-profile-header__link"
       @click.capture="onClickProfile($event)"
-      :href="profileRoute"
     >
       <div class="ui-profile-header__image">
         <ui-lazy-invent
@@ -33,7 +34,7 @@
           {{ secondaryInfo }}
         </div>
       </div>
-    </a>
+    </component>
     <div class="ui-profile-header__more-options">
       <a
         href="#"
@@ -81,6 +82,10 @@ export default Vue.extend({
     profileRoute: {
       type: String,
       default: ''
+    },
+    hasProfileLink: {
+      type: Boolean,
+      default: false
     }
   },
   methods: {

--- a/src/components/ui-profile-header.vue
+++ b/src/components/ui-profile-header.vue
@@ -2,7 +2,7 @@
   <div class="ui-profile-header">
     <component
       :is="hasProfileLink ? 'a' : 'span'"
-      :href="profileRoute"
+      :href="hasProfileLink ? profileRoute : null"
       class="ui-profile-header__link"
       @click.capture="onClickProfile($event)"
     >


### PR DESCRIPTION
-Added new prop "hasProfileLink" to remove href on ui-influencer-header
-href null when hasProfileLink is false
related with https://nextchance.atlassian.net/browse/BH-11018